### PR TITLE
Fix dead `Click here to play now!` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ fluid_table_tennis
 
 #### Table Tennis with fluid dynamics ####
 
-[Click here to play now!](http://anirudhjoshi.github.com/fluid_table_tennis/)
+[Click here to play now!](http://anirudhjoshi.github.io/fluid_table_tennis/)
 
 [Click here to watch the video!](http://www.youtube.com/watch?v=gcF-ZenWEM4&feature=plcp)
 


### PR DESCRIPTION
Previously, this link used the incorrect TLD (`.com`).
Replaced with `.io`; link now works as expected